### PR TITLE
1. Fix for error when a node module only contains an invisible folder

### DIFF
--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -15,11 +15,13 @@ gyp_rebuild_inside_node_modules () {
       if [ $isBinaryModule != "yes" ]; then
         if [ -d ./node_modules ]; then
           cd ./node_modules
-          for module in ./*; do
-            cd $module
-            check_for_binary_modules
-            cd ..
-          done
+          if [ "$(ls ./ )" ]; then
+            for module in ./*; do
+              cd $module
+              check_for_binary_modules
+              cd ..
+            done
+	      fi
           cd ../
         fi
       fi


### PR DESCRIPTION
I got an issue when node_modules contains a package with only an invisible folder in the node_modules folder: 

```
[x.com] - Uploading bundle
[x.com] - Uploading bundle: SUCCESS
[x.com] - Setting up Environment Variables
[x.com] - Setting up Environment Variables: SUCCESS
[x.com] - Invoking deployment process
[x.com] x Invoking deployment process: FAILED

	-----------------------------------STDERR-----------------------------------
	bash: line 46: [: ./Sorting: binary operator expected
	bash: line 50: [: ./Sorting: binary operator expected
	bash: line 54: [: ./Sorting: binary operator expected
	bash: line 18: cd: ./*: No such file or directory
	-----------------------------------STDOUT-----------------------------------
	----------------------------------------------------------------------------
```

The following package only contained a './bin' folder: 
           `../tmp/bundle/programs/server/npm/node_modules/meteor/fortawesome_fontawesome/node_modules/del/node_modules`

The problem was resolved by checking if the folder is empty.